### PR TITLE
WIP: feat(Application.php): load in-folder-search from files app

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -34,6 +34,7 @@ class Application extends App implements IBootstrap {
 	/** @psalm-suppress PossiblyUnusedMethod */
 	public function __construct() {
 		parent::__construct(self::APP_ID);
+		\OCP\Util::addScript('files', 'search');
 	}
 
 	public function register(IRegistrationContext $context): void {


### PR DESCRIPTION
Might be a silly way but the search plugin of the files app `folderSearch.ts` is loaded for the files app and standard settings but not our custom app. The Style was in fact not wrong but the search was missing a plugin