### PR TITLE
chore(Application.php): conditionally load files search script in sim…

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -34,7 +34,6 @@ class Application extends App implements IBootstrap {
 	/** @psalm-suppress PossiblyUnusedMethod */
 	public function __construct() {
 		parent::__construct(self::APP_ID);
-		\OCP\Util::addScript('files', 'search');
 	}
 
 	public function register(IRegistrationContext $context): void {

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -107,6 +107,8 @@ class PageController extends Controller {
 			$this->getCustomClientURL()
 		);
 
+		Util::addScript('files', 'search');
+
 		return new TemplateResponse(
 			Application::APP_ID,
 			'index',

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -210,6 +210,23 @@ class PageControllerTest extends TestCase {
 		$this->l10nFactory->expects($this->atMost(1))
 			->method('getLanguages')
 			->willReturn($this->mockAvailableLanguages);
+
+		$this->resetUtilState();
+	}
+
+	protected function tearDown(): void {
+		$this->resetUtilState();
+		parent::tearDown();
+	}
+
+	/**
+	 * Reset Util script and style state for clean test isolation
+	 */
+	private function resetUtilState(): void {
+		\OC_Util::$scripts = [];
+		\OC_Util::$styles = [];
+		self::invokePrivate(\OCP\Util::class, 'scripts', [[]]);
+		self::invokePrivate(\OCP\Util::class, 'scriptDeps', [[]]);
 	}
 
 	/**
@@ -394,5 +411,18 @@ class PageControllerTest extends TestCase {
 			});
 
 		$this->controller->index();
+	}
+
+	public function testFileSearchScriptInjection(): void {
+		$scripts = Util::getScripts();
+
+		$this->assertNotContains('files/js/search', $scripts, 'File search script should NOT be injected');
+
+		$this->controller->index();
+
+		$scripts = Util::getScripts();
+
+		$this->assertContains('files/l10n/en', $scripts, 'File search script i18n should be injected');
+		$this->assertContains('files/js/search', $scripts, 'File search script should be injected');
 	}
 }


### PR DESCRIPTION
Fix context menu language not depending on Setting > Language

The simplesettings app was loading files/search script on every page load (due to being globally enabled), which interfered with language detection causing browser language to override user configured language.

Run test via:
```shell
../d-n-t/container/dev bash -c "cd apps-custom/simplesettings/ && phpunit -c tests/phpunit.xml --colors=always --fail-on-warning --fail-on-risky"
````