### PR TITLE
chore: bump max-version to 33 (HDNEXT-1606)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 	<category>tools</category>
 	<bugs>https://github.com/IONOS-Productivity/nc-simple-settings</bugs>
 	<dependencies>
-		<nextcloud min-version="30" max-version="31"/>
+		<nextcloud min-version="30" max-version="33"/>
 	</dependencies>
 	<!--
 	- no navigations configured, we'll redirect from the /app/settings path

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
 	},
 	"require": {
 		"bamarni/composer-bin-plugin": "^1.8",
-		"php": "^8.1"
+		"php": "^8.2"
 	},
 	"require-dev": {
-		"nextcloud/ocp": "^v31.0.6",
+		"nextcloud/ocp": "^v33.0.0",
 		"roave/security-advisories": "dev-latest"
 	},
 	"config": {
@@ -42,7 +42,7 @@
 		"optimize-autoloader": true,
 		"sort-packages": true,
 		"platform": {
-			"php": "8.1"
+			"php": "8.2"
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	},
 	"require": {
 		"bamarni/composer-bin-plugin": "^1.8",
-		"php": "^8.2"
+		"php": "^8.1"
 	},
 	"require-dev": {
 		"nextcloud/ocp": "^v33.0.0",
@@ -42,7 +42,7 @@
 		"optimize-autoloader": true,
 		"sort-packages": true,
 		"platform": {
-			"php": "8.2"
+			"php": "8.1"
 		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82681f881444734880a84290b5466e59",
+    "content-hash": "524da7374b90919ed33224ab70187148",
     "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
@@ -1265,11 +1265,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.1"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.2"
+        "php": "8.1"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c43699eb13688bda00527f9d670d5946",
+    "content-hash": "82681f881444734880a84290b5466e59",
     "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
@@ -67,20 +67,20 @@
     "packages-dev": [
         {
             "name": "nextcloud/ocp",
-            "version": "v31.0.6",
+            "version": "v33.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "bec55048b46eadbd2c564f2b26c9486a43f958c2"
+                "reference": "f5a898fb7795fa28a135f528105b8628df6d97f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/bec55048b46eadbd2c564f2b26c9486a43f958c2",
-                "reference": "bec55048b46eadbd2c564f2b26c9486a43f958c2",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f5a898fb7795fa28a135f528105b8628df6d97f5",
+                "reference": "f5a898fb7795fa28a135f528105b8628df6d97f5",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1 || ~8.2 || ~8.3 || ~8.4",
+                "php": "~8.1 || ~8.2 || ~8.3 || ~8.4 || ~8.5",
                 "psr/clock": "^1.0",
                 "psr/container": "^2.0.2",
                 "psr/event-dispatcher": "^1.0",
@@ -89,7 +89,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-stable31": "31.0.0-dev"
+                    "dev-stable33": "33.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -109,9 +109,9 @@
             "description": "Composer package containing Nextcloud's public OCP API and the unstable NCU API",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/v31.0.6"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/v33.0.2"
             },
-            "time": "2025-05-28T00:52:27+00:00"
+            "time": "2026-03-27T01:17:36+00:00"
         },
         {
             "name": "psr/clock",
@@ -1265,11 +1265,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "^8.2"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.1"
+        "php": "8.2"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -223,8 +223,6 @@ class PageControllerTest extends TestCase {
 	 * Reset Util script and style state for clean test isolation
 	 */
 	private function resetUtilState(): void {
-		\OC_Util::$scripts = [];
-		\OC_Util::$styles = [];
 		self::invokePrivate(\OCP\Util::class, 'scripts', [[]]);
 		self::invokePrivate(\OCP\Util::class, 'scriptDeps', [[]]);
 	}


### PR DESCRIPTION
## Summary

- Bump `max-version` from `31` to `33` in `appinfo/info.xml`
- Update `nextcloud/ocp` from `^v31.0.6` to `^v33.0.0` in `composer.json`
- Require PHP `^8.2` (NC33 minimum)

## Audit

NC32/33 API audit confirmed no blocking changes:
- `OC_Helper::humanFileSize` etc. — already using `OCP\Util` ✅
- `@nextcloud/files` v4 breaking changes — not imported ✅
- `app.php`, `OC_Util::addScript` — not used ✅

Jira: HDNEXT-1606