### PR TITLE
feat(simplesettings): port stable30 EU market changes to v32.0.6

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -199,6 +199,8 @@ class PageController extends Controller {
 			'apps.ios.url' => $this->config->getSystemValue('ionos_customclient_ios'),
 			'apps.windows.url' => $this->config->getSystemValue('ionos_customclient_windows'),
 			'apps.macos.url' => $this->config->getSystemValue('ionos_customclient_macos'),
+			'apps.linux.url' => $this->config->getSystemValue('ionos_customclient_linux'),
+			'apps.nautilus.url' => $this->config->getSystemValue('ionos_customclient_nautilus'),
 			'apps.ios.id' => $this->config->getSystemValue('ionos_customclient_ios_appid'),
 		];
 	}

--- a/src/components/help/Software.vue
+++ b/src/components/help/Software.vue
@@ -79,6 +79,20 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 				{{ t('simplesettings', 'Install desktop app for Windows') }}
 				<span class="symbol">&ensp;❯&ensp;</span>
 			</NcButton>
+			<NcButton
+				class="desktop-app"
+				type="primary"
+				:href="linuxUrl">
+				{{ t('simplesettings', 'Linux App Image') }}
+				<span class="symbol">&ensp;❯&ensp;</span>
+			</NcButton>
+			<NcButton
+				class="desktop-app"
+				type="primary"
+				:href="nautilusUrl">
+				{{ t('simplesettings', 'Nautilus Integration') }}
+				<span class="symbol">&ensp;❯&ensp;</span>
+			</NcButton>
 		</div>
 	</div>
 </template>
@@ -107,12 +121,16 @@ export default defineComponent({
 		const iosUrl = appLinks['apps.ios.url']
 		const macosUrl = appLinks['apps.macos.url']
 		const windowsUrl = appLinks['apps.windows.url']
+		const linuxUrl = appLinks['apps.linux.url']
+		const nautilusUrl = appLinks['apps.nautilus.url']
 
 		return {
 			androidUrl,
 			iosUrl,
 			macosUrl,
 			windowsUrl,
+			linuxUrl,
+			nautilusUrl,
 			androidSVG,
 			iosSVG,
 		}

--- a/src/components/help/Software.vue
+++ b/src/components/help/Software.vue
@@ -163,6 +163,7 @@ export default defineComponent({
 	justify-content: space-between;
 	padding-bottom: 2em;
 	max-width: var(--software-content-width);
+	gap: var(--software-gap);
 
 	.ios, .android {
 		display: flex;
@@ -177,22 +178,14 @@ export default defineComponent({
 
 .desktop-apps {
 	display: flex;
-	max-width: var(--software-content-width);
-}
-
-.mobile-apps, .desktop-apps {
-	gap: var(--software-gap);
+	flex-wrap: wrap;
+	flex: 0 0 auto;
+	gap: 1em;
 }
 
 .symbol {
 	font-size: 10px;
 	vertical-align: middle;
-}
-
-@media screen and (min-width: calc(variables.$breakpoint-mobile / 2)) {
-	.desktop-app {
-		max-width: calc(var(--software-content-width) / 2);
-	}
 }
 
 @media screen and (max-width: calc(variables.$breakpoint-mobile / 2)) {
@@ -208,7 +201,6 @@ export default defineComponent({
 
 	.desktop-apps {
 		flex-direction: column;
-		gap: 1em;
 	}
 }
 

--- a/src/components/help/Software.vue
+++ b/src/components/help/Software.vue
@@ -146,7 +146,7 @@ export default defineComponent({
 
 #software {
 	--software-content-width: 40em;
-	--software-gap: 10px;
+	--software-gap: 1em;
 	--software-qr-code-intrinsic-padding: 5px; /* padding within the image around the code (measured) */
 }
 
@@ -180,7 +180,7 @@ export default defineComponent({
 	display: flex;
 	flex-wrap: wrap;
 	flex: 0 0 auto;
-	gap: 1em;
+	gap: var(--software-gap);
 }
 
 .symbol {

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -227,8 +227,8 @@ class PageControllerTest extends TestCase {
 	 * Reset Util script and style state for clean test isolation
 	 */
 	private function resetUtilState(): void {
-		\OC_Util::$scripts = [];
 		\OC_Util::$styles = [];
+		self::invokePrivate(\OCP\Util::class, 'scriptsInit', [[]]);
 		self::invokePrivate(\OCP\Util::class, 'scripts', [[]]);
 		self::invokePrivate(\OCP\Util::class, 'scriptDeps', [[]]);
 	}

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -227,6 +227,8 @@ class PageControllerTest extends TestCase {
 	 * Reset Util script and style state for clean test isolation
 	 */
 	private function resetUtilState(): void {
+		\OC_Util::$scripts = [];
+		\OC_Util::$styles = [];
 		self::invokePrivate(\OCP\Util::class, 'scripts', [[]]);
 		self::invokePrivate(\OCP\Util::class, 'scriptDeps', [[]]);
 	}

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -404,6 +404,8 @@ class PageControllerTest extends TestCase {
 			'apps.ios.id' => 'mocked-ios-appid',
 			'apps.windows.url' => 'mocked-windows-url',
 			'apps.macos.url' => 'mocked-macos-url',
+			'apps.linux.url' => 'mocked-linux-url',
+			'apps.nautilus.url' => 'mocked-nautilus-url',
 		];
 
 		$this->initialState->expects($this->exactly(4))

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -170,6 +170,8 @@ class PageControllerTest extends TestCase {
 			'ionos_customclient_ios_appid' => 'mocked-ios-appid',
 			'ionos_customclient_windows' => 'mocked-windows-url',
 			'ionos_customclient_macos' => 'mocked-macos-url',
+			'ionos_customclient_linux' => 'mocked-linux-url',
+			'ionos_customclient_nautilus' => 'mocked-nautilus-url',
 		];
 
 		$mockUser = $this->createMock(IUser::class);
@@ -183,7 +185,7 @@ class PageControllerTest extends TestCase {
 			->with($this->equalTo($this->uid))
 			->willReturn($mockUser);
 
-		$this->config->expects($this->atMost(6))
+		$this->config->expects($this->atMost(8))
 			->method('getSystemValue')
 			->with(
 				$this->logicalOr(
@@ -193,6 +195,8 @@ class PageControllerTest extends TestCase {
 					$this->equalTo('ionos_customclient_ios_appid'),
 					$this->equalTo('ionos_customclient_windows'),
 					$this->equalTo('ionos_customclient_macos'),
+					$this->equalTo('ionos_customclient_linux'),
+					$this->equalTo('ionos_customclient_nautilus'),
 				),
 				$this->anything() // This catches any default value passed
 			)

--- a/webpack.js
+++ b/webpack.js
@@ -49,6 +49,8 @@ webpackConfig.module.rules.push({
 	type: 'asset/source',
 })
 
+webpackConfig.devtool = false
+
 webpackConfig.plugins.push(new webpack.SourceMapDevToolPlugin({
 	filename: '[file].map',
 }))


### PR DESCRIPTION
## Summary

Cherry-picks EU market and feature changes from `stable30` onto a new `ionos-dev-v32.0.6` branch, adapted for NC32.

**Changes from stable30:**
- `feat`: Add Linux App Image and Nautilus Integration download buttons
- `feat`: Expose `ionos_customclient_linux` and `ionos_customclient_nautilus` config values in PageController
- `fix`: Conditionally load `files/js/search` script in simplesettings context (moved from `Application.php` constructor to `PageController::index()`)
- `fix`: Disable devtool in build to prevent source map conflict
- `fix`: CSS gap consistency fixes in Software.vue

**NC32 adaptations:**
- Kept NC32 `@nextcloud/*` package versions (not downgraded to v30 versions)
- FA icon removal already in place — skipped the v30 FA removal commit
- `fix(PageControllerTest)`: replaced `OC_Util::$scripts` (removed in NC32) with proper `OCP\Util::$scriptsInit` reset; added missing `$scriptsInit` reset to prevent test pollution

## Test plan

- [ ] Run `make test:unit` in simplesettings — 25 tests, 0 errors, 0 deprecations
- [ ] Verify Linux and Nautilus download buttons appear in simplesettings UI when `ionos_customclient_linux` / `ionos_customclient_nautilus` are configured
- [ ] Verify `files/js/search` is injected when opening simplesettings page